### PR TITLE
feat: change the OpenGraph image's link to show correct previewing image when sending the NCC's link

### DIFF
--- a/career.html
+++ b/career.html
@@ -39,7 +39,7 @@
     <meta name="twitter:title" content="Vietnam Software Development Company" />
     <meta
       name="twitter:image"
-      content="https://www.ncc.asia/assets/images/preview.png"
+      content="https://www.ncc.plus/assets/images/preview.png"
     />
     <meta
       name="twitter:description"
@@ -66,7 +66,7 @@
     <meta
       property="og:image"
       itemprop="thumbnailUrl"
-      content="https://www.ncc.asia/assets/images/preview.png"
+      content="https://www.ncc.plus/assets/images/preview.png"
     />
     <meta property="og:type" content="website" />
     <meta property="og:image:width" content="1200" />

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     <meta name="twitter:creator" content="@ncc.asia" />
     <meta name="twitter:url" content="www.ncc.asia" />
     <meta name="twitter:title" content="Vietnam Software Development Company" />
-    <meta name="twitter:image" content="https://www.ncc.asia/assets/images/preview.png" />
+    <meta name="twitter:image" content="https://www.ncc.plus/assets/images/preview.png" />
     <meta name="twitter:description"
         content="NCC Vietnam offers professional software outsourcing services, software offshore development, mobile development and website design, all under one roof" />
     <meta name="google-site-verification" content="Mzn84zWOCoGEAuYnETuGFr2BQYt-npRDHuKWKYxAwFI" />
@@ -42,7 +42,7 @@
     <meta property="fb:app_id" content="1602025800070200" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:title" content="NCC Vietnam" />
-    <meta property="og:image" itemprop="thumbnailUrl" content="https://www.ncc.asia/assets/images/preview.png" />
+    <meta property="og:image" itemprop="thumbnailUrl" content="https://www.ncc.plus/assets/images/preview.png" />
     <meta property="og:type" content="website">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="675">

--- a/jobdetails.html
+++ b/jobdetails.html
@@ -39,7 +39,7 @@
     <meta name="twitter:title" content="Vietnam Software Development Company" />
     <meta
       name="twitter:image"
-      content="https://www.ncc.asia/assets/images/preview.png"
+      content="https://www.ncc.plus/assets/images/preview.png"
     />
     <meta
       name="twitter:description"
@@ -66,7 +66,7 @@
     <meta
       property="og:image"
       itemprop="thumbnailUrl"
-      content="https://www.ncc.asia/assets/images/preview.png"
+      content="https://www.ncc.plus/assets/images/preview.png"
     />
     <meta property="og:type" content="website" />
     <meta property="og:image:width" content="1200" />

--- a/listjobs.html
+++ b/listjobs.html
@@ -39,7 +39,7 @@
     <meta name="twitter:title" content="Vietnam Software Development Company" />
     <meta
       name="twitter:image"
-      content="https://www.ncc.asia/assets/images/preview.png"
+      content="https://www.ncc.plus/assets/images/preview.png"
     />
     <meta
       name="twitter:description"
@@ -66,7 +66,7 @@
     <meta
       property="og:image"
       itemprop="thumbnailUrl"
-      content="https://www.ncc.asia/assets/images/preview.png"
+      content="https://www.ncc.plus/assets/images/preview.png"
     />
     <meta property="og:type" content="website" />
     <meta property="og:image:width" content="1200" />


### PR DESCRIPTION
Before changing:
<img width="499" height="200" alt="image" src="https://github.com/user-attachments/assets/bd30d663-016f-40c4-ac77-c0b03e8e4de1" />

After changing:
<img width="425" height="151" alt="image" src="https://github.com/user-attachments/assets/ace68c91-d1b0-4119-8741-dc0db1a71bad" />
